### PR TITLE
Fix security bug report instructions

### DIFF
--- a/sample_output/CONTRIBUTING.md
+++ b/sample_output/CONTRIBUTING.md
@@ -89,7 +89,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 <!-- omit in toc -->
 #### How Do I Submit a Good Bug Report?
 
-> You must never report security related issues, vulnerabilities or bugs to the issue tracker, or elsewhere in public. Instead sensitive bugs must be sent by email to <security@example.com>.
+> You must never report security related issues, vulnerabilities or bugs including sensitive information to the issue tracker, or elsewhere in public. Instead sensitive bugs must be sent by email to <security@example.com>.
 <!-- You may add a PGP key to allow the messages to be sent encrypted as well. -->
 
 We use GitHub issues to track bugs and errors. If you run into an issue with the project:

--- a/templates/contributing.dot
+++ b/templates/contributing.dot
@@ -89,7 +89,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 <!-- omit in toc -->
 #### How Do I Submit a Good Bug Report?
 
-> You must never report security related issues, vulnerabilities or bugs to the issue tracker, or elsewhere in public. Instead sensitive bugs must be sent by email to <{{=it.contributing.emailSensitiveBugs}}>.
+> You must never report security related issues, vulnerabilities or bugs including sensitive information to the issue tracker, or elsewhere in public. Instead sensitive bugs must be sent by email to <{{=it.contributing.emailSensitiveBugs}}>.
 <!-- You may add a PGP key to allow the messages to be sent encrypted as well. -->
 
 We use GitHub issues to track bugs and errors. If you run into an issue with the project:


### PR DESCRIPTION
@bttger I really appreciate your work as it is very helpful to quickly provide contributions and code of conduct templates!

When reading it, I found a bit confusing on a paragraph that instructs about security reporting.

I then found in your project's README at the [Acknowledgement](https://github.com/bttger/contributing-gen#acknowledgment) section that you might have sourced that from [Celery](https://github.com/celery/celery/blob/master/CONTRIBUTING.rst#security)'s project.

In the spirit of collaboration and specially on the Hacktoberfest, I propose this small fix that aims to clarify the security reports instructions.

I hope you find that helpful.

Keep Rocking!