### PR TITLE
refactor: Introduce GitHub branch name variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ const specs = {
     project: {
         name: "Our Cool Project",
         slug: "our-cool-project",
+        defaultBranch: "main",
         repoUrl: "https://github.com/user/slug/",
-        branch_name: "main",
-        docsUrl: "https://github.com/user/slug/blob/${branch_name}/README.md",
+        docsUrl: "https://github.com/user/slug/blob/main/README.md",
     },
     contributing: {
         generate: true,

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ const specs = {
         name: "Our Cool Project",
         slug: "our-cool-project",
         repoUrl: "https://github.com/user/slug/",
-        docsUrl: "https://github.com/user/slug/blob/master/README.md",
+        branch_name: "main",
+        docsUrl: "https://github.com/user/slug/blob/${branch_name}/README.md",
     },
     contributing: {
         generate: true,

--- a/generate.js
+++ b/generate.js
@@ -5,8 +5,8 @@ const specs = {
     project: {
         name: "Our Cool Project",
         slug: "our-cool-project",
-        repoUrl: "https://github.com/user/slug/",
         defaultBranch: "main",
+        repoUrl: "https://github.com/user/slug/",
         docsUrl: "https://github.com/user/slug/blob/main/README.md",
     },
     contributing: {

--- a/generate.js
+++ b/generate.js
@@ -6,7 +6,8 @@ const specs = {
         name: "Our Cool Project",
         slug: "our-cool-project",
         repoUrl: "https://github.com/user/slug/",
-        docsUrl: "https://github.com/user/slug/blob/master/README.md",
+        branch_name: "main",
+        docsUrl: "https://github.com/user/slug/blob/${branch_name}/README.md",
     },
     contributing: {
         generate: true,

--- a/generate.js
+++ b/generate.js
@@ -6,8 +6,8 @@ const specs = {
         name: "Our Cool Project",
         slug: "our-cool-project",
         repoUrl: "https://github.com/user/slug/",
-        branch_name: "main",
-        docsUrl: "https://github.com/user/slug/blob/${branch_name}/README.md",
+        defaultBranch: "main",
+        docsUrl: "https://github.com/user/slug/blob/main/README.md",
     },
     contributing: {
         generate: true,

--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@ class ContributingGen {
         project: {
             name: "Our Cool Project",
             slug: "our-cool-project",
-            repoUrl: "https://github.com/user/slug/",
             defaultBranch: "main",
+            repoUrl: "https://github.com/user/slug/",
             docsUrl: "https://github.com/user/slug/blob/main/README.md",
         },
         contributing: {

--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ class ContributingGen {
             name: "Our Cool Project",
             slug: "our-cool-project",
             repoUrl: "https://github.com/user/slug/",
-            docsUrl: "https://github.com/user/slug/blob/master/README.md",
+            branch_name: "main",
+            docsUrl: "https://github.com/user/slug/blob/${branch_name}/README.md",
         },
         contributing: {
             generate: true,

--- a/index.js
+++ b/index.js
@@ -13,8 +13,8 @@ class ContributingGen {
             name: "Our Cool Project",
             slug: "our-cool-project",
             repoUrl: "https://github.com/user/slug/",
-            branch_name: "main",
-            docsUrl: "https://github.com/user/slug/blob/${branch_name}/README.md",
+            defaultBranch: "main",
+            docsUrl: "https://github.com/user/slug/blob/main/README.md",
         },
         contributing: {
             generate: true,

--- a/sample_output/CONTRIBUTING.md
+++ b/sample_output/CONTRIBUTING.md
@@ -29,14 +29,14 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 ## Code of Conduct
 
 This project and everyone participating in it is governed by the
-[Our Cool Project Code of Conduct](https://github.com/user/slug/blob/master/CODE_OF_CONDUCT.md).
+[Our Cool Project Code of Conduct](https://github.com/user/slug/blob/main/CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code. Please report unacceptable behavior
 to <email@example.com>.
 
 
 ## I Have a Question
 
-> If you want to ask a question, we assume that you have read the available [Documentation](https://github.com/user/slug/blob/master/README.md).
+> If you want to ask a question, we assume that you have read the available [Documentation](https://github.com/user/slug/blob/main/README.md).
 
 Before you ask a question, it is best to search for existing [Issues](https://github.com/user/slug/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
 
@@ -76,7 +76,7 @@ Depending on how large the project is, you may want to outsource the questioning
 A good bug report shouldn't leave others needing to chase you up for more information. Therefore, we ask you to investigate carefully, collect information and describe the issue in detail in your report. Please complete the following steps in advance to help us fix any potential bug as fast as possible.
 
 - Make sure that you are using the latest version.
-- Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](https://github.com/user/slug/blob/master/README.md). If you are looking for support, you might want to check [this section](#i-have-a-question)).
+- Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](https://github.com/user/slug/blob/main/README.md). If you are looking for support, you might want to check [this section](#i-have-a-question)).
 - To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/user/slug/issues?q=label%3Abug).
 - Also make sure to search the internet (including Stack Overflow) to see if users outside of the GitHub community have discussed the issue.
 - Collect information about the bug:
@@ -116,7 +116,7 @@ This section guides you through submitting an enhancement suggestion for Our Coo
 #### Before Submitting an Enhancement
 
 - Make sure that you are using the latest version.
-- Read the [documentation](https://github.com/user/slug/blob/master/README.md) carefully and find out if the functionality is already covered, maybe by an individual configuration.
+- Read the [documentation](https://github.com/user/slug/blob/main/README.md) carefully and find out if the functionality is already covered, maybe by an individual configuration.
 - Perform a [search](https://github.com/user/slug/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
 - Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature. Keep in mind that we want features that will be useful to the majority of our users and not just a small subset. If you're just targeting a minority of users, consider writing an add-on/plugin library.
 

--- a/templates/contributing.dot
+++ b/templates/contributing.dot
@@ -29,7 +29,7 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 ## Code of Conduct
 
 This project and everyone participating in it is governed by the
-[{{=it.project.name}} Code of Conduct]({{=it.project.repoUrl}}blob/master/CODE_OF_CONDUCT.md).
+[{{=it.project.name}} Code of Conduct]({{=it.project.repoUrl}}blob/{{=it.project.branch_name}}/CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code. Please report unacceptable behavior
 to <{{=it.codeOfConduct.enforcementEmail}}>.
 {{?}}

--- a/templates/contributing.dot
+++ b/templates/contributing.dot
@@ -29,7 +29,7 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 ## Code of Conduct
 
 This project and everyone participating in it is governed by the
-[{{=it.project.name}} Code of Conduct]({{=it.project.repoUrl}}blob/{{=it.project.branch_name}}/CODE_OF_CONDUCT.md).
+[{{=it.project.name}} Code of Conduct]({{=it.project.repoUrl}}blob/{{=it.project.defaultBranch}}/CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code. Please report unacceptable behavior
 to <{{=it.codeOfConduct.enforcementEmail}}>.
 {{?}}


### PR DESCRIPTION
Many open source projects decide to choose ``main`` as their branch name (rather than ``master``). This PR introduces a new variable ``branch_name`` that allows a user to choose the branch name.

Closes #3