### PR TITLE
Translate from American English to International English

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -11,38 +11,37 @@ appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards
 
-Examples of behavior that contributes to a positive environment for our
+Examples of behaviour that contributes to a positive environment for our
 community include:
 
 * Demonstrating empathy and kindness toward other people
 * Being respectful of differing opinions, viewpoints, and experiences
 * Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+* Accepting responsibility and apologising to those affected by our mistakes,
   and learning from the experience
 * Focusing on what is best not just for us as individuals, but for the
   overall community
 
-Examples of unacceptable behavior include:
+Examples of unacceptable behaviour include:
 
-* The use of sexualized language or imagery, and sexual attention or
-  advances
+* The use of sexualised language or imagery, and sexual attention or advances
 * Trolling, insulting or derogatory comments, and personal or political attacks
 * Public or private harassment
 * Publishing others' private information, such as a physical or email
   address, without their explicit permission
 * Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+professional setting
 
 ## Our Responsibilities
 
 Project maintainers are responsible for clarifying and enforcing our standards of
-acceptable behavior and will take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+acceptable behaviour and will take appropriate and fair corrective action in
+response to any instances of unacceptable behaviour.
 
 Project maintainers have the right and responsibility to remove, edit, or reject
 comments, commits, code, wiki edits, issues, and other contributions that are
 not aligned to this Code of Conduct, or to ban
-temporarily or permanently any contributor for other behaviors that they deem
+temporarily or permanently any contributor for other behaviours that they deem
 inappropriate, threatening, offensive, or harmful.
 
 ## Scope
@@ -55,7 +54,7 @@ representative at an online or offline event.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be
 reported to the community leaders responsible for enforcement at <>.
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/sample_output/CODE_OF_CONDUCT.md
+++ b/sample_output/CODE_OF_CONDUCT.md
@@ -11,21 +11,20 @@ appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards
 
-Examples of behavior that contributes to a positive environment for our
+Examples of behaviour that contributes to a positive environment for our
 community include:
 
 * Demonstrating empathy and kindness toward other people
 * Being respectful of differing opinions, viewpoints, and experiences
 * Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+* Accepting responsibility and apologising to those affected by our mistakes,
   and learning from the experience
 * Focusing on what is best not just for us as individuals, but for the
   overall community
 
-Examples of unacceptable behavior include:
+Examples of unacceptable behaviour include:
 
-* The use of sexualized language or imagery, and sexual attention or
-  advances
+* The use of sexualised language or imagery, and sexual attention or advances
 * Trolling, insulting or derogatory comments, and personal or political attacks
 * Public or private harassment
 * Publishing others' private information, such as a physical or email
@@ -36,13 +35,13 @@ Examples of unacceptable behavior include:
 ## Our Responsibilities
 
 Project maintainers are responsible for clarifying and enforcing our standards of
-acceptable behavior and will take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+acceptable behaviour and will take appropriate and fair corrective action in
+response to any instances of unacceptable behaviour.
 
 Project maintainers have the right and responsibility to remove, edit, or reject
 comments, commits, code, wiki edits, issues, and other contributions that are
 not aligned to this Code of Conduct, or to ban
-temporarily or permanently any contributor for other behaviors that they deem
+temporarily or permanently any contributor for other behaviours that they deem
 inappropriate, threatening, offensive, or harmful.
 
 ## Scope
@@ -55,7 +54,7 @@ representative at an online or offline event.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be
 reported to the community leaders responsible for enforcement at <email@example.com>.
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/sample_output/CONTRIBUTING.md
+++ b/sample_output/CONTRIBUTING.md
@@ -30,7 +30,7 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 
 This project and everyone participating in it is governed by the
 [XYZ Code of Conduct](https://github.com/user/project-slug/blob/main/CODE_OF_CONDUCT.md).
-By participating, you are expected to uphold this code. Please report unacceptable behavior
+By participating, you are expected to uphold this code. Please report unacceptable behaviour
 to <email@example.com>.
 
 
@@ -95,7 +95,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 We use GitHub issues to track bugs and errors. If you run into an issue with the project:
 
 - Open an [Issue](https://github.com/user/project-slug/issues/new). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a bug yet and not to label the issue.)
-- Explain the behavior you would expect and the actual behavior.
+- Explain the behaviour you would expect and the actual behaviour.
 - Please provide as much context as possible and describe the *reproduction steps* that someone else can follow to recreate the issue on their own. This usually includes your code. For good bug reports you should isolate the problem and create a reduced test case.
 - Provide the information you collected in the previous section.
 
@@ -127,7 +127,7 @@ Enhancement suggestions are tracked as [GitHub issues](https://github.com/user/p
 
 - Use a **clear and descriptive title** for the issue to identify the suggestion.
 - Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
-- **Describe the current behavior** and **explain which behavior you expected to see instead** and why. At this point you can also tell which alternatives do not work for you.
+- **Describe the current behaviour** and **explain which behaviour you expected to see instead** and why. At this point you can also tell which alternatives do not work for you.
 - You may want to **include screenshots and animated GIFs** which help you demonstrate the steps or point out the part which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux. <!-- this should only be included if the project has a GUI -->
 - **Explain why this enhancement would be useful** to most XYZ users. You may also want to point out the other projects that solved it better and which could serve as inspiration.
 

--- a/templates/codeOfConduct.dot
+++ b/templates/codeOfConduct.dot
@@ -11,21 +11,20 @@ appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards
 
-Examples of behavior that contributes to a positive environment for our
+Examples of behaviour that contributes to a positive environment for our
 community include:
 
 * Demonstrating empathy and kindness toward other people
 * Being respectful of differing opinions, viewpoints, and experiences
 * Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+* Accepting responsibility and apologising to those affected by our mistakes,
   and learning from the experience
 * Focusing on what is best not just for us as individuals, but for the
   overall community
 
-Examples of unacceptable behavior include:
+Examples of unacceptable behaviour include:
 
-* The use of sexualized language or imagery, and sexual attention or
-  advances
+* The use of sexualised language or imagery, and sexual attention or advances
 * Trolling, insulting or derogatory comments, and personal or political attacks
 * Public or private harassment
 * Publishing others' private information, such as a physical or email
@@ -36,15 +35,15 @@ Examples of unacceptable behavior include:
 ## Our Responsibilities
 
 Project maintainers are responsible for clarifying and enforcing our standards of
-acceptable behavior and will take appropriate and fair corrective action in
-response to any {{? it.codeOfConduct.enforcementGuidelines }}behavior that they deem inappropriate,
-threatening, offensive, or harmful.{{??}}instances of unacceptable behavior.{{?}}
+acceptable behaviour and will take appropriate and fair corrective action in
+response to any {{? it.codeOfConduct.enforcementGuidelines }}behaviour that they deem inappropriate,
+threatening, offensive, or harmful.{{??}}instances of unacceptable behaviour.{{?}}
 
 Project maintainers have the right and responsibility to remove, edit, or reject
 comments, commits, code, wiki edits, issues, and other contributions that are
 not aligned to this Code of Conduct, {{? it.codeOfConduct.enforcementGuidelines }}and will
 communicate reasons for moderation decisions when appropriate.{{??}}or to ban
-temporarily or permanently any contributor for other behaviors that they deem
+temporarily or permanently any contributor for other behaviours that they deem
 inappropriate, threatening, offensive, or harmful.{{?}}
 
 ## Scope
@@ -57,7 +56,7 @@ representative at an online or offline event.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be
 reported to the community leaders responsible for enforcement at <{{=it.codeOfConduct.enforcementEmail}}>.
 All complaints will be reviewed and investigated promptly and fairly.
 
@@ -71,19 +70,19 @@ the consequences for any action they deem in violation of this Code of Conduct:
 
 ### 1. Correction
 
-**Community Impact**: Use of inappropriate language or other behavior deemed
+**Community Impact**: Use of inappropriate language or other behaviour deemed
 unprofessional or unwelcome in the community.
 
 **Consequence**: A private, written warning from community leaders, providing
 clarity around the nature of the violation and an explanation of why the
-behavior was inappropriate. A public apology may be requested.
+behaviour was inappropriate. A public apology may be requested.
 
 ### 2. Warning
 
 **Community Impact**: A violation through a single incident or series
 of actions.
 
-**Consequence**: A warning with consequences for continued behavior. No
+**Consequence**: A warning with consequences for continued behaviour. No
 interaction with the people involved, including unsolicited interaction with
 those enforcing the Code of Conduct, for a specified period of time. This
 includes avoiding interactions in community spaces as well as external channels
@@ -93,7 +92,7 @@ permanent ban.
 ### 3. Temporary Ban
 
 **Community Impact**: A serious violation of community standards, including
-sustained inappropriate behavior.
+sustained inappropriate behaviour.
 
 **Consequence**: A temporary ban from any sort of interaction or public
 communication with the community for a specified period of time. No public or
@@ -104,7 +103,7 @@ Violating these terms may lead to a permanent ban.
 ### 4. Permanent Ban
 
 **Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
+standards, including sustained inappropriate behaviour, harassment of an
 individual, or aggression toward or disparagement of classes of individuals.
 
 **Consequence**: A permanent ban from any sort of public interaction within

--- a/templates/contributing.dot
+++ b/templates/contributing.dot
@@ -16,7 +16,7 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 {{? it.codeOfConduct.generate}}
 - [Code of Conduct](#code-of-conduct){{?}}
 - [I Have a Question](#i-have-a-question)
-- [I Want To Contribute](#i-want-to-contribute)
+  - [I Want To Contribute](#i-want-to-contribute)
   - [Reporting Bugs](#reporting-bugs)
   - [Suggesting Enhancements](#suggesting-enhancements)
   - [Your First Code Contribution](#your-first-code-contribution)
@@ -30,7 +30,7 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 
 This project and everyone participating in it is governed by the
 [{{=it.project.name}} Code of Conduct]({{=it.project.repoUrl}}/blob/{{=it.project.defaultBranch}}/CODE_OF_CONDUCT.md).
-By participating, you are expected to uphold this code. Please report unacceptable behavior
+By participating, you are expected to uphold this code. Please report unacceptable behaviour
 to <{{=it.codeOfConduct.enforcementEmail}}>.
 {{?}}
 
@@ -66,7 +66,7 @@ Depending on how large the project is, you may want to outsource the questioning
 ## I Want To Contribute
 
 > ### Legal Notice <!-- omit in toc -->
-> When contributing to this project, you must agree that you have authored 100% of the content, that you have the necessary rights to the content and that the content you contribute may be provided under the project license.
+> When contributing to this project, you must agree that you have authored 100% of the content, that you have the necessary rights to the content and that the content you contribute may be provided under the project licence.
 
 ### Reporting Bugs
 
@@ -95,7 +95,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 We use GitHub issues to track bugs and errors. If you run into an issue with the project:
 
 - Open an [Issue]({{=it.project.repoUrl}}/issues/new). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a bug yet and not to label the issue.)
-- Explain the behavior you would expect and the actual behavior.
+- Explain the behaviour you would expect and the actual behaviour.
 - Please provide as much context as possible and describe the *reproduction steps* that someone else can follow to recreate the issue on their own. This usually includes your code. For good bug reports you should isolate the problem and create a reduced test case.
 - Provide the information you collected in the previous section.
 
@@ -127,7 +127,7 @@ Enhancement suggestions are tracked as [GitHub issues]({{=it.project.repoUrl}}/i
 
 - Use a **clear and descriptive title** for the issue to identify the suggestion.
 - Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
-- **Describe the current behavior** and **explain which behavior you expected to see instead** and why. At this point you can also tell which alternatives do not work for you.
+- **Describe the current behaviour** and **explain which behaviour you expected to see instead** and why. At this point you can also tell which alternatives do not work for you.
 - You may want to **include screenshots and animated GIFs** which help you demonstrate the steps or point out the part which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux. <!-- this should only be included if the project has a GUI -->
 - **Explain why this enhancement would be useful** to most {{=it.project.name}} users. You may also want to point out the other projects that solved it better and which could serve as inspiration.
 


### PR DESCRIPTION
Translate from American English (en-US) to International English (en|en-GB|en-AU|en-NZ|en-ZA|en-IE|en-JM|en-TT).

Fixes https://github.com/bttger/contributing-gen-web/issues/41