### PR TITLE
Remove broken link in contributing.dot

### DIFF
--- a/templates/contributing.dot
+++ b/templates/contributing.dot
@@ -127,8 +127,8 @@ Enhancement suggestions are tracked as [GitHub issues]({{=it.project.repoUrl}}/i
 
 - Use a **clear and descriptive title** for the issue to identify the suggestion.
 - Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
-- **Describe the current behaviour** and **explain which behaviour you expected to see instead** and why. At this point you can also tell which alternatives do not work for you.
-- You may want to **include screenshots and animated GIFs** which help you demonstrate the steps or point out the part which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) on Linux. <!-- this should only be included if the project has a GUI -->
+- **Describe the current behavior** and **explain which behavior you expected to see instead** and why. At this point you can also tell which alternatives do not work for you.
+- You may want to **include screenshots or screen recordings** which help you demonstrate the steps or point out the part which the suggestion is related to. You can use [LICEcap](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and the built-in [screen recorder in GNOME](https://help.gnome.org/users/gnome-help/stable/screen-shot-record.html.en) or [SimpleScreenRecorder](https://github.com/MaartenBaert/ssr) on Linux. <!-- this should only be included if the project has a GUI -->
 - **Explain why this enhancement would be useful** to most {{=it.project.name}} users. You may also want to point out the other projects that solved it better and which could serve as inspiration.
 
 <!-- You might want to create an issue template for enhancement suggestions that can be used as a guide and that defines the structure of the information to be included. If you do so, reference it here in the description. -->

--- a/templates/contributing.dot
+++ b/templates/contributing.dot
@@ -30,7 +30,7 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 
 This project and everyone participating in it is governed by the
 [{{=it.project.name}} Code of Conduct]({{=it.project.repoUrl}}/blob/{{=it.project.defaultBranch}}/CODE_OF_CONDUCT.md).
-By participating, you are expected to uphold this code. Please report unacceptable behaviour
+By participating, you are expected to uphold this code. Please report unacceptable behavior
 to <{{=it.codeOfConduct.enforcementEmail}}>.
 {{?}}
 
@@ -95,7 +95,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 We use GitHub issues to track bugs and errors. If you run into an issue with the project:
 
 - Open an [Issue]({{=it.project.repoUrl}}/issues/new). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a bug yet and not to label the issue.)
-- Explain the behaviour you would expect and the actual behaviour.
+- Explain the behavior you would expect and the actual behavior.
 - Please provide as much context as possible and describe the *reproduction steps* that someone else can follow to recreate the issue on their own. This usually includes your code. For good bug reports you should isolate the problem and create a reduced test case.
 - Provide the information you collected in the previous section.
 

--- a/templates/contributing.dot
+++ b/templates/contributing.dot
@@ -128,7 +128,7 @@ Enhancement suggestions are tracked as [GitHub issues]({{=it.project.repoUrl}}/i
 - Use a **clear and descriptive title** for the issue to identify the suggestion.
 - Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
 - **Describe the current behaviour** and **explain which behaviour you expected to see instead** and why. At this point you can also tell which alternatives do not work for you.
-- You may want to **include screenshots and animated GIFs** which help you demonstrate the steps or point out the part which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux. <!-- this should only be included if the project has a GUI -->
+- You may want to **include screenshots and animated GIFs** which help you demonstrate the steps or point out the part which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) on Linux. <!-- this should only be included if the project has a GUI -->
 - **Explain why this enhancement would be useful** to most {{=it.project.name}} users. You may also want to point out the other projects that solved it better and which could serve as inspiration.
 
 <!-- You might want to create an issue template for enhancement suggestions that can be used as a guide and that defines the structure of the information to be included. If you do so, reference it here in the description. -->


### PR DESCRIPTION
The GitHub GNOME mirror no longer includes byzanz. I found a GitHub fork from git.gnome.org at https://github.com/threedaymonk/byzanz, but it is 12 years old (silentcast is 7 years old, but at least the repo is still there).

Given that byzanz is a GNOME applet, which limits the Linux systems where it would work, I think removing it is best.